### PR TITLE
Change exception to inherit from StandardError

### DIFF
--- a/lib/cloud_convert/exceptions.rb
+++ b/lib/cloud_convert/exceptions.rb
@@ -1,4 +1,4 @@
 module CloudConvert
-   class InvalidStep < Exception
+   class InvalidStep < StandardError
    end
 end


### PR DESCRIPTION
Custom exceptions should inherit from StandardError rather
than Exception, so that they are rescued by a standard rescue block.

See: https://robots.thoughtbot.com/rescue-standarderror-not-exception