### PR TITLE
Do not hardcode process / download URLs

### DIFF
--- a/lib/cloud_convert/client.rb
+++ b/lib/cloud_convert/client.rb
@@ -41,7 +41,7 @@ module CloudConvert
     ##
     # Returns an array of hash with the results from the Cloud Convert list endpoint.
     def list
-        url = "#{CloudConvert::PROTOCOL}://api.#{CloudConvert::DOMAIN}/processes"
+        url = "#{CloudConvert::PROTOCOL}://#{CloudConvert::API_DOMAIN}/processes"
         response = CloudConvert::Client.send(:get, url, {query: {apikey: self.api_key}})
         return convert_response response
     end  

--- a/lib/cloudconvert-ruby.rb
+++ b/lib/cloudconvert-ruby.rb
@@ -10,5 +10,5 @@ require "cloud_convert/lib/deep_symbolize"
 module CloudConvert
   # Your code goes here...
   PROTOCOL = "https"
-  DOMAIN = "cloudconvert.com"
+  API_DOMAIN = "api.cloudconvert.com"
 end


### PR DESCRIPTION
With a recent infrastructure upgrade, the host domains changed from *.cloudconvert.com to *.infra.cloudconvert.com.

Due a customer report we have noted that this package makes several assumptions about the host domain / URLs. This really should not be done because we might change the host domains or the output storage URLs.

This PR changes the package to always use the URLs returned by the API.