### PR TITLE
Improve URL parsing to fix issue with new CloudConvert URLs

### DIFF
--- a/lib/cloud_convert/process.rb
+++ b/lib/cloud_convert/process.rb
@@ -122,7 +122,7 @@ module CloudConvert
     end
 
     def extract_subdomain_from_url(url)
-        return url.split(".")[0].tr('/','')
+        return URI.parse(url).host.sub('.cloudconvert.com','')
     end
 
     def convert_response(response)


### PR DESCRIPTION
Cloudconvert changed their hostnames to be 'serverx.infra.cloudconvert.com'
which broke this. Using a parser and gsub to more reliably get the part of the
URL we need.